### PR TITLE
关于 Yarn Berry 的一些注意事项

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,19 @@
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
+
+# Swap the comments on the following lines if you don't wish to use zero-installs
+# Documentation here: https://yarnpkg.com/features/zero-installs
+# !.yarn/cache
+# Disable Zero-Install feature
+.pnp.*
+
 # JetBrains IDE config dir
 .idea
-# Yarn module cache
-.yarn
+# vite cache
 node_modules
 # Tauri build dir
 dist

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A color picker for Zhongguose(中国色).
 - [Vite](https://vitejs.dev/)
 - [Svelte](https://svelte.dev/)
 - [Tauri](https://tauri.app/)
-- [Yarn](https://yarnpkg.com/)
+- [Yarn Berry](https://yarnpkg.com/)
 
 ## 数据来源
 


### PR DESCRIPTION
Yarn 分为两个版本

[Yarn Classic](https://classic.yarnpkg.com/) (v1) 是直接使用npm安装的

[Yarn Berry](https://yarnpkg.com/) (v2/3/4) 是用 corepack 安装的

值得注意的是 Yarn Berry 并不与 Yarn Classic 兼容

所以至少应该写全名字消除歧义